### PR TITLE
add checkbox to pull request template for cosmic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -38,7 +38,7 @@ Additional checklist for pipeline updates (if applicable)
 - [ ] Has the pipeline version in the variables file been updated e.g. development > master
 - [ ] If the changes plausibly affect the sensitivity or other key performance metrics have these been tested and results recorded?
 - [ ] If the environment changes has this been deployed and tested in place?
-
+- [ ] If the referrals have been updated or new referrals have been added, has it been checked if the cosmic files also need updating?
 
 
 #### Name:


### PR DESCRIPTION
This is required for the cosmic gaps tool validation to ensure that when referrals are added or changed, its checked to see if the cosmic files need updating.