### PR TITLE
Add missing dollar sign to gaps_file variable

### DIFF
--- a/2_TSO500.sh
+++ b/2_TSO500.sh
@@ -263,7 +263,7 @@ if [ "$dna_or_rna" = "DNA" ]; then
         gaps_file="$depth_path"/"$hscov_outdir"/"$sample_id"_"$referral"_hotspots.gaps
 
         # hotspot gaps file may be missing for some referrals
-        if [[ -f gaps_file ]]
+        if [[ -f $gaps_file ]]
         then
 
             # only run bedtools intersect for certain referral types


### PR DESCRIPTION
## Change description
- Fix bug that meant COSMIC script wasn't run for any samples. Bug was introduced in #36 while fixing another bug, the dollar sign was left off of the `$gaps_file` variable and as such nothing entered the loop. The bug had no effect on the rest of the running of the pipeline. See issue #38.

## Justification for minor update
No effect on sensitivity

## Testing description
- End to end run of whole pipeline

## Test data location
`/Output/validations/TSO500/myeloid_test_run4/`

## Verification results
Pipeline run through successfully and required files were made