### PR TITLE
Fix Issue33 by calculating number of reads using samtools

### DIFF
--- a/2_TSO500.sh
+++ b/2_TSO500.sh
@@ -355,7 +355,7 @@ if [ "$dna_or_rna" = "DNA" ]; then
 
 
     # add to sample QC file
-    echo -e "Sample\tFastQC\tcompleted_all_steps\tcontamination_pass_fail\tcontamination_score\tcontamination_p_value\ttotal_pf_reads\tmedian_insert_size\tmedian_exon_coverage\tpct_exon_50x\tReads" > "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
+    echo -e "Sample\tFastQC\tcompleted_all_steps\tcontamination_pass_fail\tcontamination_score\tcontamination_p_value\ttotal_pf_reads\tmedian_insert_size\tmedian_exon_coverage\tpct_exon_50x\tAligned_reads" > "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
     echo -e "$sample_id\t$fastqc_status\t$completed_all_steps\t$contamination_pass_fail\t$contamination_score\t$contamination_p_value\t$total_pf_reads\t$median_insert_size\t$median_exon_coverage\t$pct_exon_50x\t$reads" >> "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
 
 fi

--- a/2_TSO500.sh
+++ b/2_TSO500.sh
@@ -348,9 +348,15 @@ if [ "$dna_or_rna" = "DNA" ]; then
         fi
     fi
 
+
+    #run samtools to get the number of reads in the bam file
+    if [[ -f ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam ]]; then
+        reads=$( samtools view -c ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam )
+
+
     # add to sample QC file
-    echo -e "Sample\tFastQC\tcompleted_all_steps\tcontamination_pass_fail\tcontamination_score\tcontamination_p_value\ttotal_pf_reads\tmedian_insert_size\tmedian_exon_coverage\tpct_exon_50x" > "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
-    echo -e "$sample_id\t$fastqc_status\t$completed_all_steps\t$contamination_pass_fail\t$contamination_score\t$contamination_p_value\t$total_pf_reads\t$median_insert_size\t$median_exon_coverage\t$pct_exon_50x" >> "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
+    echo -e "Sample\tFastQC\tcompleted_all_steps\tcontamination_pass_fail\tcontamination_score\tcontamination_p_value\ttotal_pf_reads\tmedian_insert_size\tmedian_exon_coverage\tpct_exon_50x\tReads" > "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
+    echo -e "$sample_id\t$fastqc_status\t$completed_all_steps\t$contamination_pass_fail\t$contamination_score\t$contamination_p_value\t$total_pf_reads\t$median_insert_size\t$median_exon_coverage\t$pct_exon_50x\t$reads" >> "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt
 
 fi
 

--- a/2_TSO500.sh
+++ b/2_TSO500.sh
@@ -350,9 +350,11 @@ if [ "$dna_or_rna" = "DNA" ]; then
 
 
     #run samtools to get the number of reads in the bam file
-    if [[ -f ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam ]]; then
-        reads=$( samtools view -c ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam )
-
+    if [[ -f ./analysis/"$sample_id"/Logs_Intermediates/StitchedRealigned/"$sample_id"/"$sample_id".bam ]]; then
+        reads=$( samtools view -c ./analysis/"$sample_id"/Logs_Intermediates/StitchedRealigned/"$sample_id"/"$sample_id".bam )
+    else
+        reads="NA"
+    fi
 
     # add to sample QC file
     echo -e "Sample\tFastQC\tcompleted_all_steps\tcontamination_pass_fail\tcontamination_score\tcontamination_p_value\ttotal_pf_reads\tmedian_insert_size\tmedian_exon_coverage\tpct_exon_50x\tAligned_reads" > "$output_path"/"$sample_id"_"$dna_or_rna"_QC.txt

--- a/3_TSO500.sh
+++ b/3_TSO500.sh
@@ -182,16 +182,13 @@ done
 
 # run samtools to get the number of reads in each DNA sample
 
+echo -e "Sample\tReads">> reads_DNA.txt
+
 for sample in $(cat sample_list.txt); do
-
-if [[ -f ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam ]]; then
-
-reads=$( samtools view -c ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam )
-
-echo -e "$sample\t$reads" >> reads_DNA.txt
-
-fi
-
+    if [[ -f ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam ]]; then
+        reads=$( samtools view -c ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam )
+        echo -e "$sample\t$reads" >> reads_DNA.txt
+    fi
 done
 
 

--- a/3_TSO500.sh
+++ b/3_TSO500.sh
@@ -180,18 +180,6 @@ for worksheet_id in $(cat worksheets_rna.txt); do
 done
 
 
-# run samtools to get the number of reads in each DNA sample
-
-echo -e "Sample\tReads">> reads_DNA.txt
-
-for sample in $(cat sample_list.txt); do
-    if [[ -f ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam ]]; then
-        reads=$( samtools view -c ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam )
-        echo -e "$sample\t$reads" >> reads_DNA.txt
-    fi
-done
-
-
 # move sample log files into their own folders
 for sample in $(cat sample_list.txt)
 do

--- a/3_TSO500.sh
+++ b/3_TSO500.sh
@@ -179,6 +179,22 @@ for worksheet_id in $(cat worksheets_rna.txt); do
     python "$pipeline_scripts"/contamination_TSO500.py "$worksheet_id" "$pipeline_version"
 done
 
+
+# run samtools to get the number of reads in each DNA sample
+
+for sample in $(cat sample_list.txt); do
+
+if [[ -f ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam ]]; then
+
+reads=$( samtools view -c ./analysis/"$sample"/Logs_Intermediates/StitchedRealigned/"$sample"/"$sample".bam )
+
+echo -e "$sample\t$reads" >> reads_DNA.txt
+
+fi
+
+done
+
+
 # move sample log files into their own folders
 for sample in $(cat sample_list.txt)
 do


### PR DESCRIPTION
## Change description
Add samtools to calculate the number of reads in the StitchedRealigned bam file for each sample. This metric can then be used by the AutoQC database to be able to calculate NTC contamination instead of the total_pf_reads metric produced by the app. 

## Justification for minor update
No effect on sensitivity

## Testing description
The pipeline will be run from start to finish, and the number of reads will be checked to ensure they have been calculated correctly. 

## Testing location
The test run can be found at `/Output/validations/TSO500/ntc_contamination_test_run`

## Verification results
The pipeline ran through successfully and the number of reads were calculated correctly.

New way of calculating coverage was changed from total reads to total on target reads, which is a more valid way of calculating NTC contamination. Total reads will still be kept as a warning as it successfully highlighted an adapter dimer issue, but QC will be performed against total on target reads. See CG-22-250-GEN.
