### PR TITLE
Remove tile sequence quality from QC metrics

### DIFF
--- a/2_TSO500.sh
+++ b/2_TSO500.sh
@@ -315,7 +315,7 @@ set -u
 # function to check FASTQC output
 count_qc_fails() {
     #count how many core FASTQC tests failed
-    grep -E "Basic Statistics|Per base sequence quality|Per tile sequence quality|Per sequence quality scores|Per base N content" "$1" | \
+    grep -E "Basic Statistics|Per base sequence quality|Per sequence quality scores|Per base N content" "$1" | \
     grep -v ^PASS | \
     grep -v ^WARN | \
     wc -l | \


### PR DESCRIPTION
Hi Naomi,

I have **resolved #72** by removing the tile QC check, and I've tested the function accordingly on appropriate data and it correctly outputted PASS or FAIL in line with what's on AutoQC for different samples.
(Screenshot not really needed, just experimenting with using GitHub)
![Screenshot from 2024-08-08 14-39-34](https://github.com/user-attachments/assets/f9b8454d-2280-4bb0-800d-c378dbc3a884)

Thanks, Patrick

