### PR TITLE
Update field indices for worksheet and dna_or_rna

### DIFF
--- a/2_TSO500.sh
+++ b/2_TSO500.sh
@@ -45,8 +45,8 @@ minimum_coverage="270 135"
 coverage_bed_files_path="$pipeline_dir"/hotspot_coverage
 vendor_capture_bed="$pipeline_dir"/vendorCaptureBed_100pad_updated.bed
 preferred_transcripts="$pipeline_dir"/preferred_transcripts.txt
-worksheet=$(grep "$sample_id" SampleSheet_updated.csv | cut -d, -f3)
-dna_or_rna=$(grep ${sample_id}, SampleSheet_updated.csv | cut -d, -f8)
+worksheet=$(grep "$sample_id" SampleSheet_updated.csv | cut -d, -f2)
+dna_or_rna=$(grep ${sample_id}, SampleSheet_updated.csv | cut -d, -f9)
 
 
 ##############################################################################################


### PR DESCRIPTION
Live on wren 13/04/26

Hotfix for TSO500 - samplesheet was splitting by number and not getting the RNA variable so QC files weren't being made

Better fix is to remove all of the redundant DNA code - I'll do this as a separate pull request